### PR TITLE
Load external resources asynchronously

### DIFF
--- a/samples/ClientServer/Client/Client.Console/Program.cs
+++ b/samples/ClientServer/Client/Client.Console/Program.cs
@@ -28,7 +28,7 @@ namespace AnonymousTokensConsole
             var ecParameters = CustomNamedCurves.GetByOid(X9ObjectIdentifiers.Prime256v1);
 
             var publicKeyStore = new InMemoryPublicKeyStore();
-            var publicKey = publicKeyStore.Get();
+            var publicKey = await publicKeyStore.GetAsync();
 
             _initiator = new Initiator(publicKey);
 

--- a/samples/ClientServer/Server/Server.TokenGeneration.Api/Controllers/TokenController.cs
+++ b/samples/ClientServer/Server/Server.TokenGeneration.Api/Controllers/TokenController.cs
@@ -35,7 +35,7 @@ namespace Server.TokenGeneration.Api.Controllers
 
         [Route("generate")]
         [HttpPost]
-        public async Task<GenerateTokenResponseModel> GenerateAsync(GenerateTokenRequestModel model)
+        public async Task<GenerateTokenResponseModel> Generate(GenerateTokenRequestModel model)
         {
             var k = await _privateKeyStore.GetAsync();
             var K = await _publicKeyStore.GetAsync();

--- a/samples/ClientServer/Server/Server.TokenGeneration.Api/Controllers/TokenController.cs
+++ b/samples/ClientServer/Server/Server.TokenGeneration.Api/Controllers/TokenController.cs
@@ -1,5 +1,5 @@
 using AnonymousTokens.Server.Protocol;
-using AnonymousTokens.Services.InMemory;
+using AnonymousTokens.Services;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,6 +9,8 @@ using Org.BouncyCastle.Utilities.Encoders;
 
 using Server.TokenGeneration.Api.Models;
 
+using System.Threading.Tasks;
+
 namespace Server.TokenGeneration.Api.Controllers
 {
     [ApiController]
@@ -16,28 +18,30 @@ namespace Server.TokenGeneration.Api.Controllers
     public class TokenController : ControllerBase
     {
         private readonly X9ECParameters _ecParameters;
-        private readonly TokenGenerator _tokenGenerator;
+        private readonly IPrivateKeyStore _privateKeyStore;
+        private readonly IPublicKeyStore _publicKeyStore;
+        private readonly ITokenGenerator _tokenGenerator;
 
-        public TokenController()
+        public TokenController(
+            IPrivateKeyStore privateKeyStore,
+            IPublicKeyStore publicKeyStore,
+            ITokenGenerator tokenGenerator)
         {
+            _privateKeyStore = privateKeyStore;
+            _publicKeyStore = publicKeyStore;
+            _tokenGenerator = tokenGenerator;
             _ecParameters = CustomNamedCurves.GetByOid(X9ObjectIdentifiers.Prime256v1);
-
-            var publicKeyStore = new InMemoryPublicKeyStore();
-            var publicKey = publicKeyStore.Get();
-
-            var privateKeyStore = new InMemoryPrivateKeyStore();
-            var privateKey = privateKeyStore.Get();
-
-            _tokenGenerator = new TokenGenerator(publicKey, privateKey);
         }
 
         [Route("generate")]
         [HttpPost]
-        public GenerateTokenResponseModel Generate(GenerateTokenRequestModel model)
+        public async Task<GenerateTokenResponseModel> GenerateAsync(GenerateTokenRequestModel model)
         {
+            var k = await _privateKeyStore.GetAsync();
+            var K = await _publicKeyStore.GetAsync();
             var P = _ecParameters.Curve.DecodePoint(Hex.Decode(model.PAsHex));
 
-            var token = _tokenGenerator.GenerateToken(_ecParameters, P);
+            var token = _tokenGenerator.GenerateToken(k, K.Q, _ecParameters, P);
             var Q = token.Q;
             var c = token.c;
             var z = token.z;

--- a/samples/ClientServer/Server/Server.TokenGeneration.Api/Startup.cs
+++ b/samples/ClientServer/Server/Server.TokenGeneration.Api/Startup.cs
@@ -1,4 +1,8 @@
 
+using AnonymousTokens.Server.Protocol;
+using AnonymousTokens.Services;
+using AnonymousTokens.Services.InMemory;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +17,12 @@ namespace Server.Backend
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+
+            // Configure AnonymousTokens DI
+            services.AddSingleton<ISeedStore, InMemorySeedStore>();
+            services.AddSingleton<IPrivateKeyStore, InMemoryPrivateKeyStore>();
+            services.AddSingleton<IPublicKeyStore, InMemoryPublicKeyStore>();
+            services.AddSingleton<ITokenGenerator, TokenGenerator>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/ClientServer/Server/Server.TokenVerification.Api/Controllers/TokenController.cs
+++ b/samples/ClientServer/Server/Server.TokenVerification.Api/Controllers/TokenController.cs
@@ -33,7 +33,7 @@ namespace Server.TokenVerification.Api.Controllers
 
         [Route("verify")]
         [HttpPost]
-        public async Task<bool> VerifyAsync(VerifyTokenRequestModel model)
+        public async Task<bool> Verify(VerifyTokenRequestModel model)
         {
             var k = await _privateKeyStore.GetAsync();
             var t = Hex.Decode(model.tAsHex);

--- a/samples/ClientServer/Server/Server.TokenVerification.Api/Controllers/TokenController.cs
+++ b/samples/ClientServer/Server/Server.TokenVerification.Api/Controllers/TokenController.cs
@@ -1,7 +1,6 @@
 
 using AnonymousTokens.Server.Protocol;
 using AnonymousTokens.Services;
-using AnonymousTokens.Services.InMemory;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,6 +10,8 @@ using Org.BouncyCastle.Utilities.Encoders;
 
 using Server.TokenVerification.Api.Models;
 
+using System.Threading.Tasks;
+
 namespace Server.TokenVerification.Api.Controllers
 {
     [ApiController]
@@ -18,26 +19,27 @@ namespace Server.TokenVerification.Api.Controllers
     public class TokenController : ControllerBase
     {
         private readonly X9ECParameters _ecParameters;
-        private readonly TokenVerifier _tokenVerifier;
+        private readonly IPrivateKeyStore _privateKeyStore;
+        private readonly ITokenVerifier _tokenVerifier;
 
-        public TokenController(ISeedStore seedStore)
+        public TokenController(
+            IPrivateKeyStore privateKeyStore,
+            ITokenVerifier tokenVerifier)
         {
+            _privateKeyStore = privateKeyStore;
+            _tokenVerifier = tokenVerifier;
             _ecParameters = CustomNamedCurves.GetByOid(X9ObjectIdentifiers.Prime256v1);
-
-            var privateKeyStore = new InMemoryPrivateKeyStore();
-            var privateKey = privateKeyStore.Get();
-
-            _tokenVerifier = new TokenVerifier(privateKey, seedStore);
         }
 
         [Route("verify")]
         [HttpPost]
-        public bool Verify(VerifyTokenRequestModel model)
+        public async Task<bool> VerifyAsync(VerifyTokenRequestModel model)
         {
+            var k = await _privateKeyStore.GetAsync();
             var t = Hex.Decode(model.tAsHex);
             var W = _ecParameters.Curve.DecodePoint(Hex.Decode(model.WAsHex));
 
-            var isValid = _tokenVerifier.VerifyToken(_ecParameters.Curve, t, W);
+            var isValid = await _tokenVerifier.VerifyTokenAsync(k, _ecParameters.Curve, t, W);
 
             return isValid;
         }

--- a/samples/ClientServer/Server/Server.TokenVerification.Api/Startup.cs
+++ b/samples/ClientServer/Server/Server.TokenVerification.Api/Startup.cs
@@ -1,4 +1,5 @@
 
+using AnonymousTokens.Server.Protocol;
 using AnonymousTokens.Services;
 using AnonymousTokens.Services.InMemory;
 
@@ -17,7 +18,10 @@ namespace Server.VerificationBackend
         {
             services.AddControllers();
 
+            // Configure AnonymousTokens DI
             services.AddSingleton<ISeedStore, InMemorySeedStore>();
+            services.AddSingleton<IPrivateKeyStore, InMemoryPrivateKeyStore>();
+            services.AddSingleton<ITokenVerifier, TokenVerifier>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/AnonymousTokens.Server/Protocol/TokenGenerator.cs
+++ b/src/AnonymousTokens.Server/Protocol/TokenGenerator.cs
@@ -1,6 +1,5 @@
 
 using Org.BouncyCastle.Asn1.X9;
-using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Security;
 
@@ -10,36 +9,30 @@ using ECPoint = Org.BouncyCastle.Math.EC.ECPoint;
 
 namespace AnonymousTokens.Server.Protocol
 {
-    public class TokenGenerator
+    public interface ITokenGenerator
     {
-        /// <summary>
-        /// Private key for the token scheme.
-        /// </summary>
-        private readonly BigInteger _k;
+        public (ECPoint Q, BigInteger c, BigInteger z) GenerateToken(
+            BigInteger k,
+            ECPoint K,
+            X9ECParameters ecParameters,
+            ECPoint P);
+    }
 
-        /// <summary>
-        /// Public key for the token scheme.
-        /// </summary>
-        private readonly ECPoint _K;
-
-        /// <summary>
-        /// Creates an instance of TokenGenerator with a key pair.
-        /// </summary>
-        /// <param name="publicKeyParameters">Parameters containing the public key K.</param>
-        /// <param name="k">The private key.</param>
-        public TokenGenerator(ECPublicKeyParameters publicKeyParameters, BigInteger k)
-        {
-            _k = k;
-            _K = publicKeyParameters.Q;
-        }
-
+    public class TokenGenerator : ITokenGenerator
+    {
         /// <summary>
         /// Used by the token service. Signs the point submitted by the initiator in order to create a token, and outputs a proof of validity.
         /// </summary>
+        /// <param name="k">The private key for the token scheme</param>
+        /// <param name="K">The public key for the token scheme</param>
         /// <param name="ecParameters">Curve parameters</param>
         /// <param name="P">Point submitted by the app</param>
         /// <returns>A signed point Q and a Chaum-Pedersen proof (c,z) proving that the point is signed correctly</returns>
-        public (ECPoint Q, BigInteger c, BigInteger z) GenerateToken(X9ECParameters ecParameters, ECPoint P)
+        public (ECPoint Q, BigInteger c, BigInteger z) GenerateToken(
+            BigInteger k,
+            ECPoint K,
+            X9ECParameters ecParameters,
+            ECPoint P)
         {
             var curve = ecParameters.Curve;
 
@@ -48,10 +41,10 @@ namespace AnonymousTokens.Server.Protocol
                 throw new Exception("P is not a valid point on the curve");
 
             // Compute Q = k*P
-            var Q = P.Multiply(_k);
+            var Q = P.Multiply(k);
 
             // Chaum-Pedersen proof of correct signature
-            var (c, z) = CreateProof(ecParameters, P, Q);
+            var (c, z) = CreateProof(k, K, ecParameters, P, Q);
 
             return (Q, c, z);
         }
@@ -60,11 +53,18 @@ namespace AnonymousTokens.Server.Protocol
         /// Used by the token service. Creates a full transcript of a Chaum-Pedersen protocol instance, using the strong Fiat-Shamir transform.
         /// The Chaum-Pedersen proof proves that the same secret key k is used to compute K = k*G and Q = k*P, without revealing k.
         /// </summary>
+        /// <param name="k">The private key.</param>
+        /// <param name="K">The public key.</param>
         /// <param name="ecParameters">Curve parameters</param>
         /// <param name="P">Point submitted by the initiator</param>
         /// <param name="Q">Point signed using the secret key</param>
         /// <returns></returns>
-        private (BigInteger c, BigInteger z) CreateProof(X9ECParameters ecParameters, ECPoint P, ECPoint Q)
+        private (BigInteger c, BigInteger z) CreateProof(
+            BigInteger k,
+            ECPoint K,
+            X9ECParameters ecParameters,
+            ECPoint P,
+            ECPoint Q)
         {
             var random = new SecureRandom();
 
@@ -77,10 +77,10 @@ namespace AnonymousTokens.Server.Protocol
             // Computes Y = r*P
             ECPoint Y = P.Multiply(r);
 
-            BigInteger c = CPChallengeGenerator.CreateChallenge(ecParameters.G, P, _K, Q, X, Y);
+            BigInteger c = CPChallengeGenerator.CreateChallenge(ecParameters.G, P, K, Q, X, Y);
 
             // Compute proof z = r - ck mod N
-            BigInteger z = r.Subtract(c.Multiply(_k)).Mod(ecParameters.Curve.Order);
+            BigInteger z = r.Subtract(c.Multiply(k)).Mod(ecParameters.Curve.Order);
 
             return (c, z);
         }

--- a/src/AnonymousTokens.Server/Protocol/TokenVerifier.cs
+++ b/src/AnonymousTokens.Server/Protocol/TokenVerifier.cs
@@ -3,47 +3,60 @@ using AnonymousTokens.Services;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Math.EC;
 
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Server.Protocol
 {
-    public class TokenVerifier
+    public interface ITokenVerifier
+    {
+        public Task<bool> VerifyTokenAsync(
+            BigInteger k,
+            ECCurve curve,
+            byte[] t,
+            ECPoint W);
+    }
+
+    public class TokenVerifier : ITokenVerifier
     {
         /// <summary>
-        /// Private key for the token scheme.
+        /// The store to save used seeds and search within for seed t.
         /// </summary>
-        private readonly BigInteger _k;
         private readonly ISeedStore _seedStore;
 
         /// <summary>
         /// Creates an instance of TokenGenerator with the private key and a store for t.
         /// </summary>
-        /// <param name="k">The private key.</param>
         /// <param name="seedStore">The storage for t.</param>
-        public TokenVerifier(BigInteger k, ISeedStore seedStore)
+        public TokenVerifier(ISeedStore seedStore)
         {
-            _k = k;
             _seedStore = seedStore;
         }
 
         /// <summary>
         /// Used by the token verifier. It recreates the initial point from the initiator, signs it, and verifies that they are equal.
         /// </summary>
+        /// <param name="k">The private key for the token scheme</param>
         /// <param name="curve">Curve parameters</param>
         /// <param name="t">Seed for the initial point chosen by the initiator</param>
         /// <param name="W">Token received from the initiator</param>
         /// <returns>True if the token is valid, otherwise false</returns>
-        public bool VerifyToken(ECCurve curve, byte[] t, ECPoint W)
+        public async Task<bool> VerifyTokenAsync(
+            BigInteger k,
+            ECCurve curve,
+            byte[] t,
+            ECPoint W)
         {
             // Check if token t is received earlier
-            if (_seedStore.Exists(t))
+            if (await _seedStore.ExistsAsync(t))
                 return false;
 
-            _seedStore.Save(t);
+            await _seedStore.SaveAsync(t);
 
             var T = ECCurveHash.HashToWeierstrassCurve(curve, t);
             if (T == null)
                 return false;
 
-            var V = T.Multiply(_k);
+            var V = T.Multiply(k);
             return V.Equals(W);
         }
     }

--- a/src/AnonymousTokens/Services/IPrivateKeyStore.cs
+++ b/src/AnonymousTokens/Services/IPrivateKeyStore.cs
@@ -1,9 +1,11 @@
 using Org.BouncyCastle.Math;
 
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Services
 {
     public interface IPrivateKeyStore
     {
-        public BigInteger Get();
+        public Task<BigInteger> GetAsync();
     }
 }

--- a/src/AnonymousTokens/Services/IPublicKeyStore.cs
+++ b/src/AnonymousTokens/Services/IPublicKeyStore.cs
@@ -1,9 +1,11 @@
 using Org.BouncyCastle.Crypto.Parameters;
 
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Services
 {
     public interface IPublicKeyStore
     {
-        public ECPublicKeyParameters Get();
+        public Task<ECPublicKeyParameters> GetAsync();
     }
 }

--- a/src/AnonymousTokens/Services/ISeedStore.cs
+++ b/src/AnonymousTokens/Services/ISeedStore.cs
@@ -1,8 +1,10 @@
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Services
 {
     public interface ISeedStore
     {
-        bool Exists(byte[] t);
-        bool Save(byte[] t);
+        Task<bool> ExistsAsync(byte[] t);
+        Task<bool> SaveAsync(byte[] t);
     }
 }

--- a/src/AnonymousTokens/Services/InMemory/InMemoryPrivateKeyStore.cs
+++ b/src/AnonymousTokens/Services/InMemory/InMemoryPrivateKeyStore.cs
@@ -2,19 +2,21 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Services.InMemory
 {
     public class InMemoryPrivateKeyStore : IPrivateKeyStore
     {
         private const string ResourceFile = "private-key.pem";
 
-        public BigInteger Get()
+        public Task<BigInteger> GetAsync()
         {
             var resource = $"{EmbeddedResourceConstants.ResourceBasePath}{ResourceFile}";
 
             var keyPair = (AsymmetricCipherKeyPair)EmbeddedPemResource.Load(resource);
 
-            return ((ECPrivateKeyParameters)keyPair.Private).D;
+            return Task.FromResult(((ECPrivateKeyParameters)keyPair.Private).D);
         }
     }
 }

--- a/src/AnonymousTokens/Services/InMemory/InMemoryPublicKeyStore.cs
+++ b/src/AnonymousTokens/Services/InMemory/InMemoryPublicKeyStore.cs
@@ -1,17 +1,18 @@
 using Org.BouncyCastle.Crypto.Parameters;
 
+using System.Threading.Tasks;
+
 namespace AnonymousTokens.Services.InMemory
 {
-
     public class InMemoryPublicKeyStore : IPublicKeyStore
     {
         private const string ResourceFile = "public-key.pem";
 
-        public ECPublicKeyParameters Get()
+        public Task<ECPublicKeyParameters> GetAsync()
         {
             var resource = $"{EmbeddedResourceConstants.ResourceBasePath}{ResourceFile}";
 
-            return (ECPublicKeyParameters)EmbeddedPemResource.Load(resource);
+            return Task.FromResult((ECPublicKeyParameters)EmbeddedPemResource.Load(resource));
         }
     }
 }

--- a/src/AnonymousTokens/Services/InMemory/InMemorySeedStore.cs
+++ b/src/AnonymousTokens/Services/InMemory/InMemorySeedStore.cs
@@ -2,6 +2,7 @@
 using Org.BouncyCastle.Utilities.Encoders;
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace AnonymousTokens.Services.InMemory
 {
@@ -9,20 +10,20 @@ namespace AnonymousTokens.Services.InMemory
     {
         private static readonly HashSet<string> _storage = new HashSet<string>();
 
-        public bool Exists(byte[] t)
+        public Task<bool> ExistsAsync(byte[] t)
         {
             var tAsHex = Hex.ToHexString(t);
 
-            return _storage.Contains(tAsHex);
+            return Task.FromResult(_storage.Contains(tAsHex));
         }
 
-        public bool Save(byte[] t)
+        public Task<bool> SaveAsync(byte[] t)
         {
             var tAsHex = Hex.ToHexString(t);
 
             _storage.Add(tAsHex);
 
-            return true;
+            return Task.FromResult(true);
         }
     }
 }


### PR DESCRIPTION
Add async-support for loading the keys from storage and async-operations for the seed store.

Proposed design-change for `TokenGenerator` and `TokenVerifier`:

* to pass keys in each public method instead of the class-constructor. Reason is that the keys are loaded asynchronously and we can't use async-methods in constructors. Didn't find other suitable techniques since we don't allow initial null-values (making lazy-loading them per-use not an option either). 