### PR TITLE
Omit release asset

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,16 +47,6 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: ${{ contains(github.ref, '-') }} # Prerelease if vX.Y.Z-<any-suffix>
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./artifacts.zip
-          asset_name: artifacts.zip
-          asset_content_type: application/zip
 
       # NuGet publish
       - name: Push to NuGet

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <RepositoryUrl>https://github.com/HenrikWM/anonymous-tokens</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Fixes wrong path for `artifact.zip` when creating a release. Let's instead improve this later on by publishing the created NuGet-packages as release assets instead. Might also not be needed as they'll just be ready & available in the NuGet-registry.